### PR TITLE
infra: Fix PR deployment action

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -15,34 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: ./repo
+          path: ./${{ github.event.number }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
-      - run: |
-          cd repo
-          REF=$(echo ${{ github.event.number }} | sed 's/\//\\\//g')
-          echo "baseurl: /hardware-software-interface/$REF/" >> _config.yaml
+      - name: Install dependencies
+        run: bundle install
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: ./repo
-          file: ./repo/Dockerfile
-          push: false
-          load: true
-          tags: hardware-software-interface-${{ github.event.number }}:latest
-          cache-from: type=gha
-          cache-to: type=gha
-
-      - name: Load Image
-        run: |
-          mkdir -p ${{ github.event.number }}
-          docker image list
-          docker run -v $GITHUB_WORKSPACE/repo:/usr/src/app hardware-software-interface-${{ github.event.number }}:latest
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus


### PR DESCRIPTION
Build the website without using the container. It still requires the action to run `bundle install`, despite being included in the `Dockerfile` for some reason.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [ ] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [ ] Tested your changes against relevant architectures and platforms;
- [ ] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
